### PR TITLE
Remove self-influence kwargs from everywhere

### DIFF
--- a/quanda/explainers/base.py
+++ b/quanda/explainers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Sized, Union
+from typing import List, Optional, Sized, Union
 
 import torch
 
@@ -54,7 +54,7 @@ class BaseExplainer(ABC):
         return targets
 
     @cache_result
-    def self_influence(self, **kwargs: Any) -> torch.Tensor:
+    def self_influence(self, batch_size: int = 32) -> torch.Tensor:
         """
         Base class implements computing self influences by explaining the train dataset one by one
 
@@ -62,7 +62,6 @@ class BaseExplainer(ABC):
         :param kwargs:
         :return:
         """
-        batch_size = kwargs.get("batch_size", 32)
 
         # Pre-allcate memory for influences, because torch.cat is slow
         influences = torch.empty((self.dataset_length,), device=self.device)

--- a/quanda/explainers/utils.py
+++ b/quanda/explainers/utils.py
@@ -40,9 +40,9 @@ def self_influence_fn_from_explainer(
     explainer_cls: type,
     model: torch.nn.Module,
     train_dataset: torch.utils.data.Dataset,
-    self_influence_kwargs: dict,
     cache_dir: Optional[str] = None,
     model_id: Optional[str] = None,
+    batch_size: int = 32,
     **kwargs: Any,
 ) -> torch.Tensor:
     explainer = _init_explainer(
@@ -54,4 +54,4 @@ def self_influence_fn_from_explainer(
         **kwargs,
     )
 
-    return explainer.self_influence(**self_influence_kwargs)
+    return explainer.self_influence(batch_size=batch_size)

--- a/tests/explainers/wrappers/test_captum_influence.py
+++ b/tests/explainers/wrappers/test_captum_influence.py
@@ -473,7 +473,6 @@ def test_captum_tracincp_self_influence(test_id, model, dataset, checkpoints, me
         checkpoints=checkpoints,
         checkpoints_load_func=get_load_state_dict_func("cpu"),
         device="cpu",
-        outer_loop_by_checkpoints=True,
         **method_kwargs,
     )
     assert torch.allclose(explanations, explanations_exp), "Training data attributions are not as expected"


### PR DESCRIPTION
Similarly to the `explain`method, the `self-influence` method of explainers now doesn't have any kwargs, for convenience and uniformity.


Closes #95.