### PR TITLE
feat: Introducing Task Literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ In addition to the built-in explainers, **quanda** supports the evaluation of cu
 <summary><b>Step 1. Create an explainer class</b></summary>
 
 Your custom explainer should inherit from the base [Explainer](quanda/explainers/base.py) class provided by **quanda**. The first step is to initialize your custom explainer within the `__init__` method.
+
 ```python
 from quanda.explainers.base import Explainer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["interpretability", "xai", "machine learning", "deep learning"]
 
 dependencies = [
     "numpy>=1.19.5",
-    "torch>=1.13.1",
+    "torch>=1.13.1,<=2.2.1",
     "lightning>=1.4.0",
     "torchmetrics>=1.4.0",
     "tqdm>=4.0.0",

--- a/quanda/explainers/base.py
+++ b/quanda/explainers/base.py
@@ -92,16 +92,16 @@ class Explainer(ABC):
     @abstractmethod
     def explain(
         self,
-        test_data: torch.Tensor,
-        targets: Union[List[int], torch.Tensor],
+        test_data: Any,
+        targets: Any,
     ) -> torch.Tensor:
         """Abstract method for computing influence scores for the test samples.
 
         Parameters
         ----------
-        test_data : torch.Tensor
+        test_data : Any
             Test samples for which influence scores are computed.
-        targets : Union[List[int], torch.Tensor]
+        targets : Any
             Labels for the test samples.
 
         Returns

--- a/quanda/explainers/base.py
+++ b/quanda/explainers/base.py
@@ -13,6 +13,7 @@ from quanda.utils.common import (
     load_last_checkpoint,
 )
 from quanda.utils.datasets import OnDeviceDataset
+from quanda.utils.tasks import TaskLiterals
 
 
 class Explainer(ABC):
@@ -22,10 +23,13 @@ class Explainer(ABC):
 
     """
 
+    accepted_tasks: List[TaskLiterals] = []
+
     def __init__(
         self,
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
+        task: TaskLiterals = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         **kwargs,
@@ -34,10 +38,15 @@ class Explainer(ABC):
 
         Parameters
         ----------
+        task
         model : Union[torch.nn.Module, pl.LightningModule]
             The model to be used for the influence computation.
         train_dataset : torch.utils.data.Dataset
             Training dataset to be used for the influence computation.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification", "text_classification",
+            "causal_lm".
         checkpoints : Optional[Union[str, List[str]]], optional
             Path to the model checkpoint file(s), defaults to None.
         checkpoints_load_func : Optional[Callable[..., Any]], optional
@@ -47,6 +56,12 @@ class Explainer(ABC):
             Additional keyword arguments passed to the explainer.
 
         """
+        if task not in self.accepted_tasks:
+            raise ValueError(
+                f"Task {task} not supported by this explainer. "
+                f"Supported tasks: {self.accepted_tasks}"
+            )
+
         self.device: Union[str, torch.device]
         self.model = model
 

--- a/quanda/explainers/random.py
+++ b/quanda/explainers/random.py
@@ -6,6 +6,7 @@ import torch
 
 from quanda.explainers import Explainer
 from quanda.utils.common import cache_result, ds_len
+from quanda.utils.tasks import TaskLiterals
 
 
 class RandomExplainer(Explainer):
@@ -14,6 +15,8 @@ class RandomExplainer(Explainer):
     The explanations are generated with independent values sampled from a
     uniform distribution in [0,1].
     """
+
+    accepted_tasks: List[TaskLiterals] = ["image_classification"]
 
     def __init__(
         self,
@@ -42,8 +45,8 @@ class RandomExplainer(Explainer):
         """
         super().__init__(
             model=model,
-            checkpoints=checkpoints,
             train_dataset=train_dataset,
+            checkpoints=checkpoints,
             checkpoints_load_func=checkpoints_load_func,
         )
 

--- a/quanda/explainers/wrappers/captum_influence.py
+++ b/quanda/explainers/wrappers/captum_influence.py
@@ -36,6 +36,7 @@ from quanda.utils.common import (
 )
 from quanda.utils.datasets import OnDeviceDataset
 from quanda.utils.functions import cosine_similarity
+from quanda.utils.tasks import TaskLiterals
 
 logger = logging.getLogger(__name__)
 
@@ -43,12 +44,15 @@ logger = logging.getLogger(__name__)
 class CaptumInfluence(Explainer, ABC):
     """Base class for the Captum explainers."""
 
+    accepted_tasks: List[TaskLiterals] = ["image_classification"]
+
     def __init__(
         self,
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
         explainer_cls: type,
         explain_kwargs: Any,
+        task: TaskLiterals = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
     ):
@@ -64,6 +68,10 @@ class CaptumInfluence(Explainer, ABC):
             The class of the explainer from Captum.
         explain_kwargs : Any
             Additional keyword arguments for the explainer.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification", "text_classification",
+            "causal_lm".
         checkpoints : Optional[Union[str, List[str]]], optional
             Path to the model checkpoint file(s), defaults to None.
         checkpoints_load_func : Optional[Callable[..., Any]], optional
@@ -73,8 +81,9 @@ class CaptumInfluence(Explainer, ABC):
         """
         super().__init__(
             model=model,
-            checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
+            checkpoints=checkpoints,
             checkpoints_load_func=checkpoints_load_func,
         )
         self.explainer_cls = explainer_cls
@@ -140,6 +149,7 @@ class CaptumSimilarity(CaptumInfluence):
         train_dataset: torch.utils.data.Dataset,
         model_id: str,
         layers: Union[str, List[str]],
+        task: TaskLiterals = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         cache_dir: str = "./cache",
@@ -169,6 +179,9 @@ class CaptumSimilarity(CaptumInfluence):
             Training dataset to be used for the influence computation.
         layers : Union[str, List[str]]
             Layers of the model for which the activations are computed.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification".
         checkpoints_load_func : Optional[Callable], optional
             Function to load checkpoints. If None, a default function is used.
             Defaults to None.
@@ -204,6 +217,7 @@ class CaptumSimilarity(CaptumInfluence):
             checkpoints=checkpoints,
             checkpoints_load_func=checkpoints_load_func,
             train_dataset=train_dataset,
+            task=task,
             explainer_cls=SimilarityInfluence,
             explain_kwargs=explainer_kwargs,
         )
@@ -488,6 +502,7 @@ class CaptumArnoldi(CaptumInfluence):
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
         checkpoints: Union[str, List[str]],
+        task: TaskLiterals = "image_classification",
         loss_fn: Union[torch.nn.Module, Callable] = torch.nn.CrossEntropyLoss(
             reduction="none"
         ),
@@ -516,6 +531,9 @@ class CaptumArnoldi(CaptumInfluence):
             The model to be used for the influence computation.
         checkpoints : Union[str, List[str]]
             Checkpoints for the model.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification".
         train_dataset : torch.utils.data.Dataset
             Training dataset to be used for the influence computation.
         loss_fn : Union[torch.nn.Module, Callable], optional
@@ -607,6 +625,7 @@ class CaptumArnoldi(CaptumInfluence):
             model=model,
             checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
             explainer_cls=ArnoldiInfluenceFunction,
             explain_kwargs=explainer_kwargs,
             checkpoints_load_func=checkpoints_load_func,
@@ -808,6 +827,7 @@ class CaptumTracInCP(CaptumInfluence):
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
         checkpoints: Union[str, List[str]],
+        task: TaskLiterals = "image_classification",
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         layers: Optional[List[str]] = None,
         loss_fn: Optional[
@@ -829,6 +849,10 @@ class CaptumTracInCP(CaptumInfluence):
             Training dataset to be used for the influence computation.
         checkpoints : Union[str, List[str]]
             Checkpoints for the model.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification", "text_classification",
+            "causal_lm".
         checkpoints_load_func : Optional[Callable], optional
             Function to load checkpoints. If None, a default function is used.
             Defaults to None.
@@ -873,6 +897,7 @@ class CaptumTracInCP(CaptumInfluence):
             model=model,
             checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
             explainer_cls=TracInCP,
             explain_kwargs=explainer_kwargs,
             checkpoints_load_func=checkpoints_load_func,
@@ -1067,6 +1092,7 @@ class CaptumTracInCPFast(CaptumInfluence):
         final_fc_layer: torch.nn.Module,
         train_dataset: torch.utils.data.Dataset,
         checkpoints: Union[str, List[str]],
+        task: TaskLiterals = "image_classification",
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         loss_fn: Optional[
             Union[torch.nn.Module, Callable]
@@ -1089,6 +1115,9 @@ class CaptumTracInCPFast(CaptumInfluence):
             Training dataset to be used for the influence computation.
         checkpoints : Union[str, List[str]]
             Checkpoints for the model.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification".
         checkpoints_load_func : Optional[Callable[..., Any]], optional
             Function to load checkpoints. If None, a default function is used.
         loss_fn : Optional[Union[torch.nn.Module, Callable]], optional
@@ -1127,6 +1156,7 @@ class CaptumTracInCPFast(CaptumInfluence):
             model=model,
             checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
             explainer_cls=TracInCPFast,
             explain_kwargs=explainer_kwargs,
             checkpoints_load_func=checkpoints_load_func,
@@ -1315,6 +1345,7 @@ class CaptumTracInCPFastRandProj(CaptumInfluence):
         final_fc_layer: torch.nn.Module,
         train_dataset: torch.utils.data.Dataset,
         checkpoints: Union[str, List[str]],
+        task: TaskLiterals = "image_classification",
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         loss_fn: Union[torch.nn.Module, Callable] = torch.nn.CrossEntropyLoss(
             reduction="sum"
@@ -1340,6 +1371,9 @@ class CaptumTracInCPFastRandProj(CaptumInfluence):
             Training dataset to be used for the influence computation.
         checkpoints : Union[str, List[str]]
             Checkpoints for the model.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification".
         checkpoints_load_func : Optional[Callable[..., Any]], optional
             Function to load checkpoints. If None, a default function is used.
         loss_fn : Union[torch.nn.Module, Callable], optional
@@ -1403,6 +1437,7 @@ class CaptumTracInCPFastRandProj(CaptumInfluence):
             model=model,
             checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
             explainer_cls=TracInCPFastRandProj,
             explain_kwargs=explainer_kwargs,
             checkpoints_load_func=checkpoints_load_func,

--- a/quanda/explainers/wrappers/representer_points.py
+++ b/quanda/explainers/wrappers/representer_points.py
@@ -161,7 +161,6 @@ class RepresenterPoints(Explainer):
 
     """
 
-
     accepted_tasks: List[TaskLiterals] = ["image_classification"]
 
     def __init__(

--- a/quanda/explainers/wrappers/representer_points.py
+++ b/quanda/explainers/wrappers/representer_points.py
@@ -39,6 +39,7 @@ from quanda.utils.common import (
     map_location_context,
     process_targets,
 )
+from quanda.utils.tasks import TaskLiterals
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +161,9 @@ class RepresenterPoints(Explainer):
 
     """
 
+
+    accepted_tasks: List[TaskLiterals] = ["image_classification"]
+
     def __init__(
         self,
         model: Union[torch.nn.Module, L.LightningModule],
@@ -167,6 +171,7 @@ class RepresenterPoints(Explainer):
         model_id: str,
         features_layer: str,
         classifier_layer: str,
+        task: TaskLiterals = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         cache_dir: str = "./cache",
@@ -195,6 +200,10 @@ class RepresenterPoints(Explainer):
             The name of the penuultimate layer of the model.
         classifier_layer : str
             The name of the final classifier layer of the model.
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options: "image_classification", "text_classification",
+            "causal_lm".
         checkpoints : Optional[Union[str, List[str]]], optional
             Path to the model checkpoint file(s), defaults to None.
         checkpoints_load_func : Optional[Callable[..., Any]], optional
@@ -228,8 +237,9 @@ class RepresenterPoints(Explainer):
         logger.info("Initializing Representer Point Selection explainer...")
         super(RepresenterPoints, self).__init__(
             model=model,
-            checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
+            checkpoints=checkpoints,
             checkpoints_load_func=checkpoints_load_func,
         )
 

--- a/quanda/explainers/wrappers/trak_wrapper.py
+++ b/quanda/explainers/wrappers/trak_wrapper.py
@@ -66,7 +66,7 @@ class TRAK(Explainer):
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
         model_id: str,
-        task: str = "image_classification",
+        task: TaskLiterals = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         cache_dir: str = "./cache",

--- a/quanda/explainers/wrappers/trak_wrapper.py
+++ b/quanda/explainers/wrappers/trak_wrapper.py
@@ -16,7 +16,6 @@ from typing import (
 import lightning as L
 import torch
 from trak import TRAKer
-from trak.modelout_functions import AbstractModelOutput
 from trak.projectors import BasicProjector, CudaProjector, NoOpProjector
 from trak.utils import get_matrix_mult
 
@@ -26,6 +25,7 @@ from quanda.explainers.utils import (
     self_influence_fn_from_explainer,
 )
 from quanda.utils.common import ds_len, process_targets
+from quanda.utils.tasks import TaskLiterals
 
 logger = logging.getLogger(__name__)
 
@@ -59,15 +59,17 @@ class TRAK(Explainer):
 
     """
 
+    accepted_tasks: List[TaskLiterals] = ["image_classification"]
+
     def __init__(
         self,
         model: Union[torch.nn.Module, L.LightningModule],
         train_dataset: torch.utils.data.Dataset,
         model_id: str,
+        task: str = "image_classification",
         checkpoints: Optional[Union[str, List[str]]] = None,
         checkpoints_load_func: Optional[Callable[..., Any]] = None,
         cache_dir: str = "./cache",
-        task: Union[AbstractModelOutput, str] = "image_classification",
         projector: TRAKProjectorLiteral = "basic",
         proj_dim: int = 2048,
         proj_type: TRAKProjectionTypeLiteral = "normal",
@@ -94,8 +96,9 @@ class TRAK(Explainer):
             (model, checkpoint path) as two arguments, by default None.
         cache_dir : str
             The directory to save the TRAK cache.
-        task : Union[AbstractModelOutput, str], optional
-            The task of the model, by default "image_classification".
+        task: TaskLiterals, optional
+            Task type of the model. Defaults to "image_classification".
+            Possible options for TRAK: "image_classification".
         projector : TRAKProjectorLiteral, optional
             The projector to be used, by default "basic".
         proj_dim : int, optional
@@ -120,8 +123,9 @@ class TRAK(Explainer):
 
         super(TRAK, self).__init__(
             model=model,
-            checkpoints=checkpoints,
             train_dataset=train_dataset,
+            task=task,
+            checkpoints=checkpoints,
             checkpoints_load_func=checkpoints_load_func,
         )
         self.model_id = model_id

--- a/quanda/utils/tasks.py
+++ b/quanda/utils/tasks.py
@@ -1,0 +1,8 @@
+"""Utilities for tasks."""
+
+from typing import Literal
+
+
+TaskLiterals = Literal[
+    "image_classification", "text_classification", "causal_lm"
+]

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -37,10 +37,13 @@ def test_base_explainer_self_influence(
     dataset_xpl = request.getfixturevalue(dataset_xpl)
 
     Explainer.__abstractmethods__ = set()
+    Explainer.accepted_tasks = ["image_classification"]
+
     explainer = Explainer(
         model=model,
-        checkpoints=checkpoint,
         train_dataset=dataset,
+        task="image_classification",
+        checkpoints=checkpoint,
         **method_kwargs,
     )
 
@@ -54,6 +57,9 @@ def test_base_explainer_self_influence(
     mocker.patch.object(explainer, "explain", wraps=mock_explain)
 
     self_influence = explainer.self_influence()
+
+    Explainer.accepted_tasks = []
+
     assert (
         self_influence.shape[0] == dataset.__len__()
     ), "Self-influence shape does not match the dataset."
@@ -106,15 +112,19 @@ def test_base_explainer_checkpoint_loading(
         expected_state_dict = model.state_dict()
 
     Explainer.__abstractmethods__ = set()
+    Explainer.accepted_tasks = ["image_classification"]
+
     explainer = Explainer(
         model=model,
-        checkpoints=checkpoint,
         train_dataset=dataset,
+        task="image_classification",
+        checkpoints=checkpoint,
         **method_kwargs,
     )
 
     loaded_state_dict = explainer.model.state_dict()
 
+    Explainer.accepted_tasks = []
     assert torch.allclose(
         list(loaded_state_dict.values())[0],
         list(expected_state_dict.values())[0],


### PR DESCRIPTION
- The library now includes a list of task literals: `image_classification`, `text_classification`, `causal_lm`.
- Every Explainer specifies accepted tasks.
- All explainers in the library currently only accept `image_classification`.

Closes #248.